### PR TITLE
Data pipeline API improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationData"
 uuid = "3d44aec0-db1b-416b-9784-2428c815ea7f"
 authors = ["Scottish Covid Research Consortium"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -9,7 +9,6 @@ import Pkg
 export
     FileAPI,
     StandardAPI,
-    SimpleNetworkSimAPI,
     read_estimate,
     read_distribution,
     read_sample,

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -127,9 +127,20 @@ function read_sample(api::FileAPI, data_product, component)
     return convert(Float64, d)
 end
 
+"""
+    read_array(api::FileAPI, data_product, component)
+
+Read an array using `api`.
+
+## Returns
+`NamedTuple{(:data, :dimensions, :units)}`
+"""
 function read_array(api::FileAPI, data_product, component)
-    d = py"read_array($(api.pyapi), $data_product, $component)"
-    return d
+    # The python API returns Array(data=data, dimensions=dimensions, units=units)
+    # Disable automatic conversion with 'o' at the end
+    d = py"read_array($(api.pyapi), $data_product, $component)"o
+    # Convert to NamedTuple
+    return (data=d.data, dimensions=d.dimensions, units=d.units)
 end
 
 function read_table(api::FileAPI, data_product, component)

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -31,6 +31,14 @@ StandardAPI(config_filename) do api
     ...
 end
 ```
+
+The following also works, but needs an explicit `close` call to write out the access file:
+```
+api = StandardAPI(config_filename)
+read_table(api, ...)
+...
+close(api) # writes out the access file
+```
 """
 struct StandardAPI <: FileAPI
     pyapi::PyObject
@@ -66,6 +74,10 @@ function StandardAPI(f::Function, config_filename)
         result = f(StandardAPI(pyapi))
     end
     return result
+end
+
+function Base.close(api::FileAPI)
+    py"$(api.pyapi).close()"
 end
 
 function read_estimate(api::FileAPI, data_product, component)

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -10,26 +10,6 @@ function pycallinit()
     from data_pipeline_api.simple_network_sim_api import SimpleNetworkSimAPI
     from data_pipeline_api.standard_api import StandardAPI
     print(SimpleNetworkSimAPI)
-
-    def read_estimate(api, data, component):
-        print("[PYTHON]: Reading estimate")
-        return api.read_estimate(data, component)
-
-    def read_distribution(api, data, component):
-        print("[PYTHON]: Reading distribution")
-        return api.read_distribution(data, component)
-
-    def read_sample(api, data, component):
-        print("[PYTHON]: Reading sample")
-        return api.read_sample(data, component)
-
-    def read_array(api, data, component):
-        print("[PYTHON]: Reading array")
-        return api.read_array(data, component)
-
-    def read_table(api, data, component):
-        print("[PYTHON]: Reading table")
-        return api.read_table(data, component)
     """
 end
 
@@ -113,17 +93,17 @@ function SimpleNetworkSimAPI(f::Function, config_filename)
 end
 
 function read_estimate(api::FileAPI, data_product, component)
-    d = py"read_estimate($(api.pyapi), $data_product, $component)"
+    d = py"$(api.pyapi).read_estimate($data_product, $component)"
     return d
 end
 
 function read_distribution(api::FileAPI, data_product, component)
-    d = py"read_distribution($(api.pyapi), $data_product, $component)"o
+    d = py"$(api.pyapi).read_distribution($data_product, $component)"o
     return _parse_dist(d)
 end
 
 function read_sample(api::FileAPI, data_product, component)
-    d = py"read_sample($(api.pyapi), $data_product, $component)"
+    d = py"$(api.pyapi).read_sample($data_product, $component)"
     return convert(Float64, d)
 end
 
@@ -138,13 +118,13 @@ Read an array using `api`.
 function read_array(api::FileAPI, data_product, component)
     # The python API returns Array(data=data, dimensions=dimensions, units=units)
     # Disable automatic conversion with 'o' at the end
-    d = py"read_array($(api.pyapi), $data_product, $component)"o
+    d = py"$(api.pyapi).read_array($data_product, $component)"o
     # Convert to NamedTuple
     return (data=d.data, dimensions=d.dimensions, units=d.units)
 end
 
 function read_table(api::FileAPI, data_product, component)
-    d = py"read_table($(api.pyapi), $data_product, $component)"
+    d = py"$(api.pyapi).read_table($data_product, $component)"
     return DataFrames.DataFrame(Pandas.DataFrame(d))
 end
 

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -118,7 +118,7 @@ function read_estimate(api::FileAPI, data_product, component)
 end
 
 function read_distribution(api::FileAPI, data_product, component)
-    d = py"read_distribution($(api.pyapi), $data_product, $component)"
+    d = py"read_distribution($(api.pyapi), $data_product, $component)"o
     return _parse_dist(d)
 end
 
@@ -149,18 +149,13 @@ function read_table(api::FileAPI, data_product, component)
 end
 
 function _parse_dist(d)
-    if d.dist.name == "gamma"
-        # Get mean and variance
-        mv = py"$d.stats(moments='mv')"
-        mean = mv[1][1]
-        var = mv[2][1]
-        # α = shape
-        # θ = scale
-        # mean = αθ
-        # var = αθ^2
-        θ = var / mean
-        α = mean / θ
-        return Gamma(α, θ)
+    name = d.dist.name
+    kwds = d.kwds
+    if name == "gamma"
+        return Gamma(kwds["a"], kwds["scale"])
+    end
+    if name == "norm"
+        return Normal(kwds["loc"], kwds["scale"])
     end
     error("Unable to parse $d as a distribution")
 end

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -7,9 +7,8 @@ using Pandas
 
 function pycallinit()
     py"""
-    from data_pipeline_api.simple_network_sim_api import SimpleNetworkSimAPI
     from data_pipeline_api.standard_api import StandardAPI
-    print(SimpleNetworkSimAPI)
+    print(StandardAPI)
     """
 end
 
@@ -34,23 +33,6 @@ end
 ```
 """
 struct StandardAPI <: FileAPI
-    pyapi::PyObject
-end
-
-"""
-    SimpleNetworkSimAPI <: FileAPI
-
-Wrapper around `data_pipeline_api.simple_network_sim_api.SimpleNetworkSimAPI`
-
-Preferred use is:
-```
-SimpleNetworkSimAPI(config_filename) do api
-    df = read_table(api, ...)
-    ...
-end
-```
-"""
-struct SimpleNetworkSimAPI <: FileAPI
     pyapi::PyObject
 end
 
@@ -80,14 +62,6 @@ function StandardAPI(f::Function, config_filename)
     # module. (They are named the same for convenience)
     @pywith py"StandardAPI($config_filename)" as pyapi begin
         result = f(StandardAPI(pyapi))
-    end
-    return result
-end
-
-function SimpleNetworkSimAPI(f::Function, config_filename)
-    result = nothing
-    @pywith py"SimpleNetworkSimAPI($config_filename)" as pyapi begin
-        result = f(SimpleNetworkSimAPI(pyapi))
     end
     return result
 end

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -36,6 +36,8 @@ struct StandardAPI <: FileAPI
     pyapi::PyObject
 end
 
+StandardAPI(config_filename::AbstractString) = StandardAPI(py"StandardAPI($config_filename)")
+
 """
     StandardAPI(f::Function, config_filename)
 

--- a/test/data/.gitignore
+++ b/test/data/.gitignore
@@ -1,0 +1,1 @@
+access-example.yaml

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -15,7 +15,7 @@
         @test read_sample(api, "parameter", "example-samples") ∈ [1, 2, 3]
 
         expected_table = DataFrame(:a => [1, 2], :b => [3, 4])
-        expected_array = ([1, 2, 3], nothing, nothing)
+        expected_array = (data=[1, 2, 3], dimensions=nothing, units=nothing)
         @test read_table(api, "object", "example-table") == expected_table
         @test read_array(api, "object", "example-array") == expected_array
     end

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -1,7 +1,7 @@
 @testset "pyapi" begin
     config = joinpath("data", "config.yaml")
 
-    StandardAPI(config) do api
+    function _testsuite(api)
         @test read_estimate(api, "parameter", "example-estimate") == 1.0
         @test read_estimate(api, "parameter", "example-distribution") == 2.0
         @test read_estimate(api, "parameter", "example-samples") == 2.0
@@ -18,5 +18,15 @@
         expected_array = (data=[1, 2, 3], dimensions=nothing, units=nothing)
         @test read_table(api, "object", "example-table") == expected_table
         @test read_array(api, "object", "example-array") == expected_array
+    end
+
+    @testset "Basic syntax" begin
+        _testsuite(StandardAPI(config))
+    end
+
+    @testset "do-block syntax" begin
+        StandardAPI(config) do api
+            _testsuite(api)
+        end
     end
 end

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -1,5 +1,7 @@
 @testset "pyapi" begin
     config = joinpath("data", "config.yaml")
+    accessfile = joinpath("data", "access-example.yaml")
+    remove_accessfile() = rm(accessfile, force=true)
 
     function _testsuite(api)
         @test read_estimate(api, "parameter", "example-estimate") == 1.0
@@ -21,12 +23,22 @@
     end
 
     @testset "Basic syntax" begin
-        _testsuite(StandardAPI(config))
+        remove_accessfile()
+        api = StandardAPI(config)
+        _testsuite(api)
+        # Need to manually close to write out access file
+        @test !isfile(accessfile)
+        close(api)
+        @test isfile(accessfile)
+        remove_accessfile()
     end
 
     @testset "do-block syntax" begin
+        remove_accessfile()
         StandardAPI(config) do api
             _testsuite(api)
         end
+        @test isfile(accessfile)
+        remove_accessfile()
     end
 end


### PR DESCRIPTION
- `read_array` returns a `NamedTuple{(:data, :dimensions, :units)}`
- distribution parsing is improved, and Normal distribution added
- python function calling simplified (removes a layer of indirection)
- remove unneeded `SimpleNetworkSimAPI` (the `StandardAPI` does everything we want I think)
- can now use the API in the following way:
```julia
julia> api = StandardAPI(config);
julia> read_array(api, "object", "example-array");
julia> close(api); # writes out the access file
```