### PR TITLE
Add API write methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationData"
 uuid = "3d44aec0-db1b-416b-9784-2428c815ea7f"
 authors = ["Scottish Covid Research Consortium"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/Project.toml
+++ b/Project.toml
@@ -14,3 +14,9 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[extras]
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+
+[targets]
+test = ["YAML"]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,9 @@
 using Pkg
 ENV["PYTHON"] = ""
-Pkg.build("PyCall") #
+Pkg.build("PyCall")
 
 using Conda
 
 pip = joinpath(Conda.BINDIR, "pip")
 run(`$pip install pyyaml setuptools-scm`)
-run(`$pip install git+https://github.com/ScottishCovidResponse/data_pipeline_api`)
+run(`$pip install git+https://github.com/ScottishCovidResponse/data_pipeline_api@0.5.0`)

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -13,7 +13,12 @@ export
     read_distribution,
     read_sample,
     read_array,
-    read_table
+    read_table,
+    write_estimate,
+    write_distribution,
+    write_samples,
+    write_array,
+    write_table
 
 
 include("units.jl")

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -7,7 +7,7 @@ using HDF5
 import Pkg
 
 export
-    FileAPI,
+    DataPipelineAPI,
     StandardAPI,
     read_estimate,
     read_distribution,

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -8,6 +8,7 @@ import Pkg
 
 export
     DataPipelineAPI,
+    DataPipelineIssue,
     StandardAPI,
     read_estimate,
     read_distribution,

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -129,3 +129,53 @@ function _parse_dist(d)
     end
     error("Unable to parse $d as a distribution")
 end
+
+function write_estimate(
+    api::DataPipelineAPI, data_product, component, estimate;
+    description=nothing, issues=nothing
+)
+    return py"$(api.pyapi).write_estimate(
+        $data_product, $component, $estimate,
+        description=$description, issues=$issues
+    )"
+end
+
+function write_distribution(
+    api::DataPipelineAPI, data_product, component, distribution::Distribution;
+    description=nothing, issues=nothing
+)
+    return py"$(api.pyapi).write_distribution(
+        $data_product, $component, $distribution,
+        description=$description, issues=$issues
+    )"
+end
+
+function write_samples(
+    api::DataPipelineAPI, data_product, component, samples;
+    description=nothing, issues=nothing
+)
+    return py"$(api.pyapi).write_samples(
+        $data_product, $component, $samples,
+        description=$description, issues=$issues
+    )"
+end
+
+function write_array(
+    api::DataPipelineAPI, data_product, component, array;
+    description=nothing, issues=nothing
+)
+    return py"$(api.pyapi).write_array(
+        $data_product, $component, $array,
+        description=$description, issues=$issues
+    )"
+end
+
+function write_table(
+    api::DataPipelineAPI, data_product, component, table;
+    description=nothing, issues=nothing
+)
+    return py"$(api.pyapi).write_table(
+        $data_product, $component, $table,
+        description=$description, issues=$issues
+    )"
+end

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -93,7 +93,7 @@ An issue associated with a data product or component.
 """
 struct DataPipelineIssue
     description::AbstractString
-    severity::AbstractString
+    severity::Integer
 end
 
 function Base.close(api::DataPipelineAPI)

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -45,11 +45,13 @@ close(api) # writes out the access file
 """
 struct StandardAPI <: DataPipelineAPI
     pyapi::PyObject
-end
 
-function StandardAPI(config_filename::AbstractString, uri, git_sha)
-    isfile(config_filename) || throw(ArgumentError("File $config_filename not found"))
-    return StandardAPI(py"StandardAPI($config_filename, $uri, $git_sha)")
+    function StandardAPI(config_filename, uri, git_sha)
+        isfile(config_filename) || throw(ArgumentError("File $config_filename not found"))
+        return StandardAPI(py"StandardAPI($config_filename, $uri, $git_sha)")
+    end
+
+    StandardAPI(pyapi::PyObject) = new(pyapi)
 end
 
 """

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -81,6 +81,20 @@ function StandardAPI(f::Function, config_filename, uri, git_sha)
     return result
 end
 
+"""
+    DataPipelineIssue
+
+An issue associated with a data product or component.
+
+## Fields
+- `description`
+- `severity`
+"""
+struct DataPipelineIssue
+    description::AbstractString
+    severity::AbstractString
+end
+
 function Base.close(api::DataPipelineAPI)
     py"$(api.pyapi).file_api.close()"
 end
@@ -135,8 +149,11 @@ end
 
 function write_estimate(
     api::DataPipelineAPI, data_product, component, estimate;
-    description=nothing, issues=nothing
+    description=nothing, issues::AbstractVector{DataPipelineIssue}=DataPipelineIssue[]
 )
+    if isempty(issues)
+        issues = nothing
+    end
     return py"$(api.pyapi).write_estimate(
         $data_product, $component, $estimate,
         description=$description, issues=$issues
@@ -145,8 +162,11 @@ end
 
 function write_distribution(
     api::DataPipelineAPI, data_product, component, distribution::Distribution;
-    description=nothing, issues=nothing
+    description=nothing, issues::AbstractVector{DataPipelineIssue}=DataPipelineIssue[]
 )
+    if isempty(issues)
+        issues = nothing
+    end
     return py"$(api.pyapi).write_distribution(
         $data_product, $component, $distribution,
         description=$description, issues=$issues
@@ -155,8 +175,11 @@ end
 
 function write_samples(
     api::DataPipelineAPI, data_product, component, samples;
-    description=nothing, issues=nothing
+    description=nothing, issues::AbstractVector{DataPipelineIssue}=DataPipelineIssue[]
 )
+    if isempty(issues)
+        issues = nothing
+    end
     return py"$(api.pyapi).write_samples(
         $data_product, $component, $samples,
         description=$description, issues=$issues
@@ -165,8 +188,11 @@ end
 
 function write_array(
     api::DataPipelineAPI, data_product, component, array;
-    description=nothing, issues=nothing
+    description=nothing, issues::AbstractVector{DataPipelineIssue}=DataPipelineIssue[]
 )
+    if isempty(issues)
+        issues = nothing
+    end
     return py"$(api.pyapi).write_array(
         $data_product, $component, $array,
         description=$description, issues=$issues
@@ -175,8 +201,11 @@ end
 
 function write_table(
     api::DataPipelineAPI, data_product, component, table;
-    description=nothing, issues=nothing
+    description=nothing, issues::AbstractVector{DataPipelineIssue}=DataPipelineIssue[]
 )
+    if isempty(issues)
+        issues = nothing
+    end
     return py"$(api.pyapi).write_table(
         $data_product, $component, $table,
         description=$description, issues=$issues

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -4,27 +4,29 @@
     remove_accessfile() = rm(accessfile, force=true)
 
     function _testsuite(api)
-        @test read_estimate(api, "parameter", "example-estimate") == 1.0
-        @test read_estimate(api, "parameter", "example-distribution") == 2.0
-        @test read_estimate(api, "parameter", "example-samples") == 2.0
+        @testset "Read API" begin
+            @test read_estimate(api, "parameter", "example-estimate") == 1.0
+            @test read_estimate(api, "parameter", "example-distribution") == 2.0
+            @test read_estimate(api, "parameter", "example-samples") == 2.0
 
-        # print(api.read_distribution("parameter", "example-estimate"))  # expected to fail
-        @test read_distribution(api, "parameter", "example-distribution") == Gamma(1.0, 2.0)
-        # print(api.read_distribution("parameter", "example-samples"))  # expected to fail
+            # print(api.read_distribution("parameter", "example-estimate"))  # expected to fail
+            @test read_distribution(api, "parameter", "example-distribution") == Gamma(1.0, 2.0)
+            # print(api.read_distribution("parameter", "example-samples"))  # expected to fail
 
-        @test read_sample(api, "parameter", "example-estimate") == 1.0
-        @test read_sample(api, "parameter", "example-distribution") isa Real
-        @test read_sample(api, "parameter", "example-samples") ∈ [1, 2, 3]
+            @test read_sample(api, "parameter", "example-estimate") == 1.0
+            @test read_sample(api, "parameter", "example-distribution") isa Real
+            @test read_sample(api, "parameter", "example-samples") ∈ [1, 2, 3]
 
-        expected_table = DataFrame(:a => [1, 2], :b => [3, 4])
-        expected_array = (data=[1, 2, 3], dimensions=nothing, units=nothing)
-        @test read_table(api, "object", "example-table") == expected_table
-        @test read_array(api, "object", "example-array") == expected_array
+            expected_table = DataFrame(:a => [1, 2], :b => [3, 4])
+            expected_array = (data=[1, 2, 3], dimensions=nothing, units=nothing)
+            @test read_table(api, "object", "example-table") == expected_table
+            @test read_array(api, "object", "example-array") == expected_array
+        end
     end
 
     @testset "Basic syntax" begin
         remove_accessfile()
-        api = StandardAPI(config)
+        api = StandardAPI(config, "test_uri", "test_git_sha")
         _testsuite(api)
         # Need to manually close to write out access file
         @test !isfile(accessfile)
@@ -35,7 +37,7 @@
 
     @testset "do-block syntax" begin
         remove_accessfile()
-        StandardAPI(config) do api
+        StandardAPI(config, "test_uri", "test_git_sha") do api
             _testsuite(api)
         end
         @test isfile(accessfile)

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -52,6 +52,8 @@
         @testset "Basic syntax" begin
             cp("data", datadir; force=true)
             remove_accessfile()
+            # Need to specify URI and git sha
+            @test_throws MethodError StandardAPI(config)
             api = StandardAPI(config, "test_uri", "test_git_sha")
             _testsuite(api)
             # Need to manually close to write out access file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Distributions
 using Pkg
 using Unitful
 using HDF5
+using YAML
 
 include("parameters.jl")
 include("data.jl")


### PR DESCRIPTION
- Closes #7 
- Also closes #11 (by just fetching a specific tag of the `data_pipeline_api` repo)
- This adds all the write wrappers I think (unless I missed something), and a bunch of tests
- I couldn't get the HDF5 write methods (`write_table / write_array`) to work, they don't error but they don't seem to actually write to the file. Those tests are marked broken for now, we can revisit.
- A few other things are also updated to make the API work with the latest python api (e.g. you now have to specify a URI and git hash when constructing the API)