### PR TITLE
Improve write_array and read_array implementations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationData"
 uuid = "3d44aec0-db1b-416b-9784-2428c815ea7f"
 authors = ["Scottish Covid Research Consortium"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Scottish Covid Research Consortium"]
 version = "0.4.1"
 
 [deps]
+AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationData"
 uuid = "3d44aec0-db1b-416b-9784-2428c815ea7f"
 authors = ["Scottish Covid Research Consortium"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -10,7 +10,7 @@ export
     DataPipelineAPI,
     DataPipelineIssue,
     StandardAPI,
-    DataPipelineDimensions,
+    DataPipelineDimension,
     DataPipelineArray,
     read_estimate,
     read_distribution,

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -1,5 +1,6 @@
 module SimulationData
 
+using AutoHashEquals
 using DataDeps
 using DataFrames
 using Distributions

--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -10,6 +10,8 @@ export
     DataPipelineAPI,
     DataPipelineIssue,
     StandardAPI,
+    DataPipelineDimensions,
+    DataPipelineArray,
     read_estimate,
     read_distribution,
     read_sample,

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -99,7 +99,7 @@ struct DataPipelineIssue
 end
 
 """
-    DataPipelineDimensions
+    DataPipelineDimension
 
 Wrapper struct for data_pipeline_api.Dimension
 
@@ -109,7 +109,7 @@ Wrapper struct for data_pipeline_api.Dimension
 - `values`
 - `units`
 """
-struct DataPipelineDimension
+@auto_hash_equals struct DataPipelineDimension
     title::Union{AbstractString, Nothing}
     names::Union{AbstractVector{<:AbstractString}, Nothing}
     values::Union{AbstractVector, Nothing}
@@ -132,7 +132,7 @@ Wrapper struct for data_pipeline_api.Array
 - `dimensions`
 - `units`
 """
-struct DataPipelineArray
+@auto_hash_equals struct DataPipelineArray
     data::AbstractArray
     dimensions::Union{AbstractVector{<:DataPipelineDimension}, Nothing}
     units::Union{AbstractString, Nothing}
@@ -141,7 +141,6 @@ struct DataPipelineArray
         return new(array, dimensions, units)
     end
 end
-
 
 function Base.close(api::DataPipelineAPI)
     py"$(api.pyapi).file_api.close()"

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -9,7 +9,9 @@
             # print(api.read_distribution("parameter-read", "example-estimate"))  # expected to fail
             @test read_distribution(api, "parameter-read", "example-distribution") == Gamma(1.0, 2.0)
             # print(api.read_distribution("parameter-read", "example-samples"))  # expected to fail
-@test read_samples(api, "parameter-read", "example-samples") == [1.0, 2.0, 3.0]
+
+            @test read_samples(api, "parameter-read", "example-samples") == [1.0, 2.0, 3.0]
+
             expected_table = DataFrame(:a => [1, 2], :b => [3, 4])
             expected_array = DataPipelineArray([1, 2, 3])
             @test read_table(api, "object-read", "example-table") == expected_table

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -15,7 +15,7 @@
             @test read_sample(api, "parameter-read", "example-samples") ∈ [1, 2, 3]
 
             expected_table = DataFrame(:a => [1, 2], :b => [3, 4])
-            expected_array = (data=[1, 2, 3], dimensions=nothing, units=nothing)
+            expected_array = DataPipelineArray([1, 2, 3])
             @test read_table(api, "object-read", "example-table") == expected_table
             @test read_array(api, "object-read", "example-array") == expected_array
         end
@@ -43,8 +43,9 @@
 
             @test_throws Exception read_estimate(api, "object-write", "example-array")
             write_array(api, "object-write", "example-array", [4, 5, 6])
-            expected_array = (data=[4, 5, 6], dimensions=nothing, units=nothing)
-            @test read_array(api, "object-write", "example-array") == expected_array
+            read_result = read_array(api, "object-write", "example-array")
+            @test read_result isa DataPipelineArray
+            @test read_result.data == [4, 5, 6]
         end
     end
 

--- a/test/pyapi.jl
+++ b/test/pyapi.jl
@@ -17,7 +17,8 @@
             expected_table = DataFrame(:a => [1, 2], :b => [3, 4])
             expected_array = DataPipelineArray([1, 2, 3])
             @test read_table(api, "object-read", "example-table") == expected_table
-            @test read_array(api, "object-read", "example-array") == expected_array
+            read_result = read_array(api, "object-read", "example-array")
+            @test read_result == expected_array
         end
 
         @testset "Write API" begin
@@ -42,10 +43,19 @@
             @test read_table(api, "object-write", "example-table") == df
 
             @test_throws Exception read_estimate(api, "object-write", "example-array")
-            write_array(api, "object-write", "example-array", [4, 5, 6])
+            dimensions = [
+                DataPipelineDimension(
+                    title="dimension 1",
+                    names=["column 1"],
+                    values=[1],
+                    units="dimension 1 units",
+                )
+            ]
+            units = "array units"
+            array = DataPipelineArray([4, 5, 6]; dimensions=dimensions, units=units)
+            write_array(api, "object-write", "example-array", array)
             read_result = read_array(api, "object-write", "example-array")
-            @test read_result isa DataPipelineArray
-            @test read_result.data == [4, 5, 6]
+            @test read_result == array
         end
     end
 


### PR DESCRIPTION
Closes #14 

- Adds new structs `DataPipelineDimension` and `DataPipelineArray` to wrap the python classes `Dimension` and `Array` defined in `data_pipeline_api`.
- Makes `read_array` and `write_array` deal with these (breaking change)
- `write_array` on an `AbstractArray` will do the conversion transparently. (In future we could also do this for e.g. `AxisArrays`).