### PR TITLE
Add wrapper function for downloading from registry

### DIFF
--- a/src/SimulationData.jl
+++ b/src/SimulationData.jl
@@ -19,7 +19,8 @@ export
     write_distribution,
     write_samples,
     write_array,
-    write_table
+    write_table,
+    download_data_registry
 
 
 include("units.jl")

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -10,6 +10,12 @@ function pycallinit()
     py"""
     import scipy
     from data_pipeline_api.standard_api import StandardAPI
+    #from data_pipeline_api import registry
+    #from data_pipeline_api.registry.common import (
+    #    DATA_REGISTRY_ACCESS_TOKEN,
+    #    DATA_REGISTRY_URL,
+    #    DEFAULT_DATA_REGISTRY_URL,
+    #)
     """
     api_version = Conda.version("data-pipeline-api")
     @info "Found data-pipeline-api v$api_version"
@@ -237,4 +243,15 @@ function write_table(
         $data_product, $component, $table,
         description=$description, issues=$issues
     )"
+end
+
+function download_registry(config_filename)
+    # Only support default for now
+    data_registry = py"DEFAULT_DATA_REGISTRY_URL"
+    return data_registry
+    #py"download_from_config_file(
+    #    config_filename=$config_filename,
+    #    data_registry_url=$data_registry,
+    #    token=$token
+    #)"
 end

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -243,6 +243,19 @@ function write_table(
     )"
 end
 
+"""
+    download_data_registry(
+        config_filename;
+        data_registry_url=py"DEFAULT_DATA_REGISTRY_URL",
+        token=""
+    )
+
+Download (a subset of) the data registry using the config specified by `config_filename`.
+
+## Keyword arguments
+- `data_registry_url`: the location of the data registry. The default is typically fine.
+- `token`: Registry access token. Shouldn't be needed for downloading.
+"""
 function download_data_registry(
     config_filename;
     data_registry_url=py"DEFAULT_DATA_REGISTRY_URL",

--- a/src/pyapi.jl
+++ b/src/pyapi.jl
@@ -10,12 +10,10 @@ function pycallinit()
     py"""
     import scipy
     from data_pipeline_api.standard_api import StandardAPI
-    #from data_pipeline_api import registry
-    #from data_pipeline_api.registry.common import (
-    #    DATA_REGISTRY_ACCESS_TOKEN,
-    #    DATA_REGISTRY_URL,
-    #    DEFAULT_DATA_REGISTRY_URL,
-    #)
+    from data_pipeline_api.registry import download
+    from data_pipeline_api.registry.common import (
+        DEFAULT_DATA_REGISTRY_URL,
+    )
     """
     api_version = Conda.version("data-pipeline-api")
     @info "Found data-pipeline-api v$api_version"
@@ -245,13 +243,25 @@ function write_table(
     )"
 end
 
-function download_registry(config_filename)
-    # Only support default for now
-    data_registry = py"DEFAULT_DATA_REGISTRY_URL"
-    return data_registry
-    #py"download_from_config_file(
-    #    config_filename=$config_filename,
-    #    data_registry_url=$data_registry,
-    #    token=$token
-    #)"
+function download_data_registry(
+    config_filename;
+    data_registry_url=py"DEFAULT_DATA_REGISTRY_URL",
+    token=""
+)
+    isfile(config_filename) || throw(ArgumentError("$config_filename not found"))
+    @info """
+        Downloading from registry: $data_registry_url
+        Using config file: $config_filename
+        ...
+    """
+    try
+        py"download.download_from_config_file(
+            config_filename=$config_filename,
+            data_registry_url=$data_registry_url,
+            token=$token
+        )"
+        @info "Registry download done"
+    catch err
+        @warn "Registry download errored" exception=err
+    end
 end


### PR DESCRIPTION
Example usage with the following `data_config.yaml`:
```yaml
data_directory: data
access_log: access-{run_id}.yaml
fail_on_hash_mismatch: True
namespace: SCRC
read:
  - where:
      data_product: human/infection/SARS-CoV-2/asymptomatic-period
      component: asymptomatic-period
```

```julia
julia> download_data_registry("data_config.yaml")
┌ Info:     Downloading from registry: https://data.scrc.uk/api/
│     Using config file: data_config.yaml
└     ...
[ Info: Registry download done
```

Successfully created the data folder:

```bash
$ ls data
human         metadata.yaml
$ cat data/metadata.yaml
- accessibility: 0
  component: asymptomatic-period
  data_product: human/infection/SARS-CoV-2/asymptomatic-period
  extension: toml
  filename: human/infection/SARS-CoV-2/asymptomatic-period/0.1.0/0.1.0.toml
  namespace: SCRC
  verified_hash: 8142974eaf721e6606830b36ffac3c3a00337a77
  version: 0.1.0
```